### PR TITLE
Update callbacks add audio feedback

### DIFF
--- a/Voysis.xcodeproj/project.pbxproj
+++ b/Voysis.xcodeproj/project.pbxproj
@@ -21,19 +21,44 @@
 		654C5E2A207B7D99002FF5E9 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 652D0461206D287200DEA61F /* Starscream.framework */; };
 		654C5E2D207B7E07002FF5E9 /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 654C5E2C207B7E07002FF5E9 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		654C5E2E207B7FD8002FF5E9 /* Voysis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65D499B220039AD6005AFF23 /* Voysis.framework */; };
-		659E8F9B202C600E00B910C7 /* HeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED711D62BDC6CDE44083F /* HeaderTests.swift */; };
+		6588B3FD20C6ECC30030445A /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A10200515E3005AFF23 /* EventType.swift */; };
+		6588B3FE20C6ECC30030445A /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A122005163F005AFF23 /* Event.swift */; };
+		6588B3FF20C6ECC30030445A /* VoysisError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED4B973DD77DA54D742C7 /* VoysisError.swift */; };
+		6588B40020C6ECC30030445A /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED948E979A37674EF9F6B /* Callback.swift */; };
+		6588B40120C6ECC30030445A /* CallbackDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED7BC04D2297004C933D8 /* CallbackDispatcher.swift */; };
+		6588B40220C6ECC30030445A /* SocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D499FA2004FD6A005AFF23 /* SocketResponse.swift */; };
+		6588B40320C6ECC30030445A /* SocketRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A08200506A3005AFF23 /* SocketRequest.swift */; };
+		6588B40420C6ECC30030445A /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED071C98AA7D34E56437C /* Context.swift */; };
+		6588B40520C6ECC30030445A /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A1C20051F2B005AFF23 /* AudioRecorder.swift */; };
+		6588B40620C6ECC30030445A /* AudioRecorderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A2C200626C2005AFF23 /* AudioRecorderImpl.swift */; };
+		6588B40720C6ECC30030445A /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6530A35C2063E2AE009B33E7 /* AudioPlayer.swift */; };
+		6588B40820C6ECC30030445A /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A212005362F005AFF23 /* Client.swift */; };
+		6588B40920C6ECC30030445A /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED054AF35482350532C57 /* ServiceProvider.swift */; };
+		6588B40A20C6ECC30030445A /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED40339BD1D764EDBEE3D /* Service.swift */; };
+		6588B40B20C6ECC30030445A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED571BE7F40936814F683 /* Config.swift */; };
+		6588B40C20C6ECC30030445A /* ServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D49A2E200627F8005AFF23 /* ServiceImpl.swift */; };
+		6588B40D20C6ECC30030445A /* Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED91D71111AA13FD3B671 /* Converter.swift */; };
+		6588B40E20C6ECC30030445A /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32EDCBADFAAF92610373FE6 /* WebSocketClient.swift */; };
+		6588B40F20C6ECC30030445A /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED342823D42A604203DD4 /* TokenManager.swift */; };
+		6588B41020C6ECC30030445A /* FeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED26DBFCEB0597E881AB2 /* FeedbackManager.swift */; };
+		6588B41220C6ECC30030445A /* VoysisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED8E85917F9571047A2E6 /* VoysisTests.swift */; };
+		6588B41320C6ECC30030445A /* ClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ECF4F6202A0DB900DB1EF1 /* ClientMock.swift */; };
+		6588B41420C6ECC30030445A /* AudioRecordManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ECF4F8202A0DDF00DB1EF1 /* AudioRecordManagerMock.swift */; };
+		6588B41520C6ECC30030445A /* HeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED711D62BDC6CDE44083F /* HeaderTests.swift */; };
+		6588B41620C6ECC30030445A /* CallbackMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED669E18E2D658D25CE2F /* CallbackMock.swift */; };
+		6588B41820C6EDF90030445A /* VoysisTests.xctest in Sources */ = {isa = PBXBuildFile; fileRef = 65D499BB20039AD6005AFF23 /* VoysisTests.xctest */; };
 		65C4AE0A202487FF008F2A88 /* voysis_on.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 65C4AE09202487FF008F2A88 /* voysis_on.mp3 */; };
-		65ECF4F32029F86900DB1EF1 /* VoysisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED8E85917F9571047A2E6 /* VoysisTests.swift */; };
-		65ECF4F7202A0DB900DB1EF1 /* ClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ECF4F6202A0DB900DB1EF1 /* ClientMock.swift */; };
-		65ECF4F9202A0DDF00DB1EF1 /* AudioRecordManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ECF4F8202A0DDF00DB1EF1 /* AudioRecordManagerMock.swift */; };
 		F32ED083A6CB664260DCB4FD /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED054AF35482350532C57 /* ServiceProvider.swift */; };
 		F32ED190FD09286815609D71 /* Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED91D71111AA13FD3B671 /* Converter.swift */; };
 		F32ED1DACC56B028C631B18F /* voysis_off.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = F32ED4E2E6A68A809AB40259 /* voysis_off.mp3 */; };
+		F32ED23A8E636C5D8703BFA0 /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED948E979A37674EF9F6B /* Callback.swift */; };
 		F32ED27475F44319E8F21CD4 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED40339BD1D764EDBEE3D /* Service.swift */; };
 		F32ED2C3487901AA33E01ABB /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED571BE7F40936814F683 /* Config.swift */; };
 		F32ED46EFB3BA8F54FCBF676 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED342823D42A604203DD4 /* TokenManager.swift */; };
 		F32EDB3A98275ED46A056A22 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32EDCBADFAAF92610373FE6 /* WebSocketClient.swift */; };
+		F32EDD4274E52FD1CCEF3ABD /* CallbackMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED669E18E2D658D25CE2F /* CallbackMock.swift */; };
 		F32EDE5AFC41237F50725DBD /* .travis.yml in Resources */ = {isa = PBXBuildFile; fileRef = F32EDBBDAC0847C4752E6BFA /* .travis.yml */; };
+		F32EDF3C829634724CD7412E /* CallbackDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED7BC04D2297004C933D8 /* CallbackDispatcher.swift */; };
 		F32EDF9CF5F43108E808C99C /* FeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32ED26DBFCEB0597E881AB2 /* FeedbackManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -86,9 +111,12 @@
 		F32ED4B973DD77DA54D742C7 /* VoysisError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoysisError.swift; sourceTree = "<group>"; };
 		F32ED4E2E6A68A809AB40259 /* voysis_off.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = voysis_off.mp3; sourceTree = "<group>"; };
 		F32ED571BE7F40936814F683 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		F32ED669E18E2D658D25CE2F /* CallbackMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallbackMock.swift; sourceTree = "<group>"; };
 		F32ED711D62BDC6CDE44083F /* HeaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderTests.swift; sourceTree = "<group>"; };
+		F32ED7BC04D2297004C933D8 /* CallbackDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallbackDispatcher.swift; sourceTree = "<group>"; };
 		F32ED8E85917F9571047A2E6 /* VoysisTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoysisTests.swift; sourceTree = "<group>"; };
 		F32ED91D71111AA13FD3B671 /* Converter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Converter.swift; sourceTree = "<group>"; };
+		F32ED948E979A37674EF9F6B /* Callback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Callback.swift; sourceTree = "<group>"; };
 		F32EDBBDAC0847C4752E6BFA /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = file.yml; path = .travis.yml; sourceTree = "<group>"; };
 		F32EDCBADFAAF92610373FE6 /* WebSocketClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -163,6 +191,7 @@
 				65ECF4F6202A0DB900DB1EF1 /* ClientMock.swift */,
 				65ECF4F8202A0DDF00DB1EF1 /* AudioRecordManagerMock.swift */,
 				F32ED711D62BDC6CDE44083F /* HeaderTests.swift */,
+				F32ED669E18E2D658D25CE2F /* CallbackMock.swift */,
 			);
 			path = VoysisTests;
 			sourceTree = "<group>";
@@ -212,6 +241,8 @@
 				65D49A10200515E3005AFF23 /* EventType.swift */,
 				65D49A122005163F005AFF23 /* Event.swift */,
 				F32ED4B973DD77DA54D742C7 /* VoysisError.swift */,
+				F32ED948E979A37674EF9F6B /* Callback.swift */,
+				F32ED7BC04D2297004C933D8 /* CallbackDispatcher.swift */,
 			);
 			path = events;
 			sourceTree = "<group>";
@@ -377,6 +408,9 @@
 				F32ED2C3487901AA33E01ABB /* Config.swift in Sources */,
 				F32ED46EFB3BA8F54FCBF676 /* TokenManager.swift in Sources */,
 				F32EDF9CF5F43108E808C99C /* FeedbackManager.swift in Sources */,
+				F32ED23A8E636C5D8703BFA0 /* Callback.swift in Sources */,
+				F32EDF3C829634724CD7412E /* CallbackDispatcher.swift in Sources */,
+				F32EDD4274E52FD1CCEF3ABD /* CallbackMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,10 +418,32 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				659E8F9B202C600E00B910C7 /* HeaderTests.swift in Sources */,
-				65ECF4F32029F86900DB1EF1 /* VoysisTests.swift in Sources */,
-				65ECF4F7202A0DB900DB1EF1 /* ClientMock.swift in Sources */,
-				65ECF4F9202A0DDF00DB1EF1 /* AudioRecordManagerMock.swift in Sources */,
+				6588B41820C6EDF90030445A /* VoysisTests.xctest in Sources */,
+				6588B3FD20C6ECC30030445A /* EventType.swift in Sources */,
+				6588B3FE20C6ECC30030445A /* Event.swift in Sources */,
+				6588B3FF20C6ECC30030445A /* VoysisError.swift in Sources */,
+				6588B40020C6ECC30030445A /* Callback.swift in Sources */,
+				6588B40120C6ECC30030445A /* CallbackDispatcher.swift in Sources */,
+				6588B40220C6ECC30030445A /* SocketResponse.swift in Sources */,
+				6588B40320C6ECC30030445A /* SocketRequest.swift in Sources */,
+				6588B40420C6ECC30030445A /* Context.swift in Sources */,
+				6588B40520C6ECC30030445A /* AudioRecorder.swift in Sources */,
+				6588B40620C6ECC30030445A /* AudioRecorderImpl.swift in Sources */,
+				6588B40720C6ECC30030445A /* AudioPlayer.swift in Sources */,
+				6588B40820C6ECC30030445A /* Client.swift in Sources */,
+				6588B40920C6ECC30030445A /* ServiceProvider.swift in Sources */,
+				6588B40A20C6ECC30030445A /* Service.swift in Sources */,
+				6588B40B20C6ECC30030445A /* Config.swift in Sources */,
+				6588B40C20C6ECC30030445A /* ServiceImpl.swift in Sources */,
+				6588B40D20C6ECC30030445A /* Converter.swift in Sources */,
+				6588B40E20C6ECC30030445A /* WebSocketClient.swift in Sources */,
+				6588B40F20C6ECC30030445A /* TokenManager.swift in Sources */,
+				6588B41020C6ECC30030445A /* FeedbackManager.swift in Sources */,
+				6588B41220C6ECC30030445A /* VoysisTests.swift in Sources */,
+				6588B41320C6ECC30030445A /* ClientMock.swift in Sources */,
+				6588B41420C6ECC30030445A /* AudioRecordManagerMock.swift in Sources */,
+				6588B41520C6ECC30030445A /* HeaderTests.swift in Sources */,
+				6588B41620C6ECC30030445A /* CallbackMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Voysis/events/Callback.swift
+++ b/Voysis/events/Callback.swift
@@ -2,11 +2,14 @@ import Foundation
 
 public protocol Callback: class {
 
+    associatedtype C : Context
+    associatedtype E : Entities
+
     /**
      Called when a successful response has been returned from server.
       -Parameter response: object representation of successful json response.
      */
-    func success(response: ApiResponse)
+    func success(response: StreamResponse<C,E>)
 
     /**
      See VoysisError for different possible error responses.

--- a/Voysis/events/Callback.swift
+++ b/Voysis/events/Callback.swift
@@ -4,12 +4,13 @@ public protocol Callback: class {
 
     /**
      Called when a successful response has been returned from server.
-      -Parameter response: response object representation of successful json response.
+      -Parameter response: object representation of successful json response.
      */
     func success(response: ApiResponse)
 
     /**
-      -Parameter error: provides throwable.
+     See VoysisError for different possible error responses.
+      -Parameter error: provides VoysisError.
      */
     func failure(error: VoysisError)
 

--- a/Voysis/events/Callback.swift
+++ b/Voysis/events/Callback.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public protocol Callback: class {
+
+    /**
+     Called when a successful response has been returned from server.
+      -Parameter response: response object representation of successful json response.
+     */
+    func success(response: ApiResponse)
+
+    /**
+      -Parameter error: provides throwable.
+     */
+    func failure(error: VoysisError)
+
+    /**
+     Called when microphone is turned on and recording begins.
+     */
+    func recordingStarted()
+
+    /**
+     Called when successful connection is made to server.
+      -Parameter queryResponse: contains information about the connection.
+    */
+    func queryResponse(queryResponse: QueryResponse)
+
+    /**
+     Called when recording finishes.
+      -Parameter reason: enum explaining why recording finished.
+     */
+    func recordingFinished(reason: FinishedReason)
+
+    /**
+     Audio data recorded from microphone.
+      -Parameter buffer: containing audio data.
+     */
+    func audioData(data: Data)
+}
+
+public extension Callback {
+
+    func audioData(data: Data) {
+        //no implementation
+    }
+
+    func recordingStarted() {
+        //no implementation
+    }
+
+    func queryResponse(query: QueryResponse) {
+        //no implementation
+    }
+
+    func recordingFinished(reason: FinishedReason) {
+        //no implementation
+    }
+}

--- a/Voysis/events/Callback.swift
+++ b/Voysis/events/Callback.swift
@@ -48,7 +48,7 @@ public extension Callback {
         //no implementation
     }
 
-    func queryResponse(query: QueryResponse) {
+    func queryResponse(queryResponse: QueryResponse) {
         //no implementation
     }
 

--- a/Voysis/events/Callback.swift
+++ b/Voysis/events/Callback.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Callback: class {
+public protocol Callback: AnyObject {
 
     associatedtype C : Context
     associatedtype E : Entities

--- a/Voysis/events/CallbackDispatcher.swift
+++ b/Voysis/events/CallbackDispatcher.swift
@@ -1,24 +1,21 @@
 import Foundation
 
-internal class CallbackDispatcher: Callback {
+internal class CallbackDispatcher<T: Callback> {
     private let dispatchQueue: DispatchQueue
-    private weak var callback: Callback?
+    private weak var callback: T?
 
-    init(_ dispatchQueue: DispatchQueue) {
+    init(_ dispatchQueue: DispatchQueue, _ callback: T) {
         self.dispatchQueue = dispatchQueue
-    }
-
-    func setCallback(callback: Callback) {
         self.callback = callback
     }
 
-    func success(response: ApiResponse) {
+    func success(_ response: StreamResponse<T.C, T.E>) {
         dispatchQueue.async {
             self.callback?.success(response: response)
         }
     }
 
-    func failure(error: VoysisError) {
+    func failure(_ error: VoysisError) {
         dispatchQueue.async {
             self.callback?.failure(error: error)
         }
@@ -30,19 +27,19 @@ internal class CallbackDispatcher: Callback {
         }
     }
 
-    func queryResponse(queryResponse: QueryResponse) {
+    func queryResponse(_ queryResponse: QueryResponse) {
         dispatchQueue.async {
             self.callback?.queryResponse(queryResponse: queryResponse)
         }
     }
 
-    func recordingFinished(reason: FinishedReason) {
+    func recordingFinished(_ reason: FinishedReason) {
         dispatchQueue.async {
             self.callback?.recordingFinished(reason: reason)
         }
     }
 
-    func audioData(data: Data) {
+    func audioData(_ data: Data) {
         dispatchQueue.async {
             self.callback?.audioData(data: data)
         }

--- a/Voysis/events/CallbackDispatcher.swift
+++ b/Voysis/events/CallbackDispatcher.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal class CallbackDispatcher<T: Callback> {
     private let dispatchQueue: DispatchQueue
-    private weak var callback: T!
+    private let callback: T
 
     init(_ dispatchQueue: DispatchQueue, _ callback: T) {
         self.dispatchQueue = dispatchQueue

--- a/Voysis/events/CallbackDispatcher.swift
+++ b/Voysis/events/CallbackDispatcher.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+internal class CallbackDispatcher: Callback {
+    private let dispatchQueue: DispatchQueue
+    private weak var callback: Callback?
+
+    init(_ dispatchQueue: DispatchQueue) {
+        self.dispatchQueue = dispatchQueue
+    }
+
+    func setCallback(callback: Callback) {
+        self.callback = callback
+    }
+
+    func success(response: ApiResponse) {
+        dispatchQueue.async {
+            self.callback?.success(response: response)
+        }
+    }
+
+    func failure(error: VoysisError) {
+        dispatchQueue.async {
+            self.callback?.failure(error: error)
+        }
+    }
+
+    func recordingStarted() {
+        dispatchQueue.async {
+            self.callback?.recordingStarted()
+        }
+    }
+
+    func queryResponse(queryResponse: QueryResponse) {
+        dispatchQueue.async {
+            self.callback?.queryResponse(queryResponse: queryResponse)
+        }
+    }
+
+    func recordingFinished(reason: FinishedReason) {
+        dispatchQueue.async {
+            self.callback?.recordingFinished(reason: reason)
+        }
+    }
+
+    func audioData(data: Data) {
+        dispatchQueue.async {
+            self.callback?.audioData(data: data)
+        }
+    }
+}

--- a/Voysis/events/CallbackDispatcher.swift
+++ b/Voysis/events/CallbackDispatcher.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal class CallbackDispatcher<T: Callback> {
     private let dispatchQueue: DispatchQueue
-    private weak var callback: T?
+    private weak var callback: T!
 
     init(_ dispatchQueue: DispatchQueue, _ callback: T) {
         self.dispatchQueue = dispatchQueue
@@ -11,37 +11,37 @@ internal class CallbackDispatcher<T: Callback> {
 
     func success(_ response: StreamResponse<T.C, T.E>) {
         dispatchQueue.async {
-            self.callback?.success(response: response)
+            self.callback.success(response: response)
         }
     }
 
     func failure(_ error: VoysisError) {
         dispatchQueue.async {
-            self.callback?.failure(error: error)
+            self.callback.failure(error: error)
         }
     }
 
     func recordingStarted() {
         dispatchQueue.async {
-            self.callback?.recordingStarted()
+            self.callback.recordingStarted()
         }
     }
 
     func queryResponse(_ queryResponse: QueryResponse) {
         dispatchQueue.async {
-            self.callback?.queryResponse(queryResponse: queryResponse)
+            self.callback.queryResponse(queryResponse: queryResponse)
         }
     }
 
     func recordingFinished(_ reason: FinishedReason) {
         dispatchQueue.async {
-            self.callback?.recordingFinished(reason: reason)
+            self.callback.recordingFinished(reason: reason)
         }
     }
 
     func audioData(_ data: Data) {
         dispatchQueue.async {
-            self.callback?.audioData(data: data)
+            self.callback.audioData(data: data)
         }
     }
 }

--- a/Voysis/events/Event.swift
+++ b/Voysis/events/Event.swift
@@ -1,4 +1,4 @@
-public struct Event {
+internal struct Event {
     public var response: ApiResponse?
     public let type: EventType
 }

--- a/Voysis/events/EventType.swift
+++ b/Voysis/events/EventType.swift
@@ -1,7 +1,10 @@
-public enum EventType {
-    case recordingStarted
+internal enum EventType {
     case audioQueryCreated
-    case recordingFinished
     case vadReceived
     case audioQueryCompleted
+}
+
+public enum FinishedReason {
+    case vadReceived
+    case manualStop
 }

--- a/Voysis/voysis/ServiceImpl.swift
+++ b/Voysis/voysis/ServiceImpl.swift
@@ -178,7 +178,7 @@ internal class ServiceImpl<C: Context, E: Entities>: Service {
                 state = .idle
                 callbackDispatcher.success(response: event.response!)
             case .audioQueryCreated:
-                callbackDispatcher.queryResponse(query: event.response as! QueryResponse)
+                callbackDispatcher.queryResponse(queryResponse: event.response as! QueryResponse)
             }
         } catch {
             cancel()

--- a/Voysis/voysis/WebSocketClient.swift
+++ b/Voysis/voysis/WebSocketClient.swift
@@ -86,6 +86,8 @@ internal class VoysisWebSocketClient: Client, WebSocketDelegate {
             if error.code != 1001 {
                 onError?(VoysisError.networkError(error.type.localizedDescription))
             }
+        }else{
+            onError?(VoysisError.unknownError)
         }
     }
 

--- a/Voysis/voysis/api/Service.swift
+++ b/Voysis/voysis/api/Service.swift
@@ -35,7 +35,7 @@ public protocol Service {
            - see `VoysisError` for all possible error types
            - this method will call back to the same thread that called `startAudioQuery`
      */
-    func startAudioQuery(context: Context?, callback : Callback)
+    func startAudioQuery<C, E, T: Callback>(context: C?, callback: T) where T.C == C, T.E == E
 
     ///Call to manually stop recording audio and process request
     func finish()

--- a/Voysis/voysis/api/Service.swift
+++ b/Voysis/voysis/api/Service.swift
@@ -1,5 +1,4 @@
 public typealias ErrorHandler = (VoysisError) -> Void
-public typealias EventHandler = (Event) -> Void
 public typealias TokenHandler = (Token) -> Void
 public typealias FeedbackHandler = (Int) -> Void
 
@@ -36,7 +35,7 @@ public protocol Service {
            - see `VoysisError` for all possible error types
            - this method will call back to the same thread that called `startAudioQuery`
      */
-    func startAudioQuery(context: Context?, eventHandler: @escaping EventHandler, errorHandler: @escaping ErrorHandler)
+    func startAudioQuery(context: Context?, callback : Callback)
 
     ///Call to manually stop recording audio and process request
     func finish()

--- a/Voysis/voysis/api/ServiceProvider.swift
+++ b/Voysis/voysis/api/ServiceProvider.swift
@@ -24,10 +24,10 @@ public struct ServiceProvider<C: Context, E: Entities> {
      -Return new instance of Voysis.Service
     */
     public static func make(config: Config, recorder: AudioRecorder, callbackQueue: DispatchQueue = DispatchQueue.main) -> Service {
-        return ServiceImpl<C, E>(
+        return ServiceImpl(
                 client: VoysisWebSocketClient(request: URLRequest(url: config.url), dispatchQueue: callbackQueue),
                 recorder: recorder,
-                callbackDispatcher: CallbackDispatcher(callbackQueue),
+                dispatchQueue: callbackQueue,
                 feedbackManager: FeedbackManager(callbackQueue),
                 tokenManager: TokenManager(refreshToken: config.refreshToken, dispatchQueue: callbackQueue),
                 userId: config.userId)

--- a/Voysis/voysis/api/ServiceProvider.swift
+++ b/Voysis/voysis/api/ServiceProvider.swift
@@ -7,7 +7,7 @@ import Foundation
  must be implemented by concrete classes that are of the same type that the user expects returned from the server.
  See the sample application for an example of a correct implementation of `Context` and `Entities`
 */
-public struct ServiceProvider<C: Context, E: Entities> {
+public struct ServiceProvider {
 
     /**
      -Parameter config: containing url endpoint and refreshToken.

--- a/Voysis/voysis/api/ServiceProvider.swift
+++ b/Voysis/voysis/api/ServiceProvider.swift
@@ -24,14 +24,12 @@ public struct ServiceProvider<C: Context, E: Entities> {
      -Return new instance of Voysis.Service
     */
     public static func make(config: Config, recorder: AudioRecorder, callbackQueue: DispatchQueue = DispatchQueue.main) -> Service {
-        let client = VoysisWebSocketClient(request: URLRequest(url: config.url), dispatchQueue: callbackQueue)
-        let tokenManager = TokenManager(refreshToken: config.refreshToken, dispatchQueue: callbackQueue)
-        let feedbackManager = FeedbackManager(callbackQueue)
-        return ServiceImpl<C, E>(client: client,
+        return ServiceImpl<C, E>(
+                client: VoysisWebSocketClient(request: URLRequest(url: config.url), dispatchQueue: callbackQueue),
                 recorder: recorder,
-                feedbackManager: feedbackManager,
-                tokenManager: tokenManager,
-                userId: config.userId,
-                dispatchQueue: callbackQueue)
+                callbackDispatcher: CallbackDispatcher(callbackQueue),
+                feedbackManager: FeedbackManager(callbackQueue),
+                tokenManager: TokenManager(refreshToken: config.refreshToken, dispatchQueue: callbackQueue),
+                userId: config.userId)
     }
 }

--- a/VoysisTests/CallbackMock.swift
+++ b/VoysisTests/CallbackMock.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+class CallbackMock: Callback {
+
+    var callback: ((String) -> Void)?
+
+    func success(response: ApiResponse) {
+        callback?("success")
+    }
+
+    func failure(error: VoysisError) {
+        callback?("failure")
+    }
+
+    func recordingStarted() {
+        callback?("recordingStarted")
+    }
+
+    func queryResponse(queryResponse: QueryResponse) {
+        callback?("queryResponse")
+    }
+
+    func recordingFinished(reason: FinishedReason) {
+        switch reason {
+        case .vadReceived:
+            callback?("vadReceived")
+        case .manualStop:
+            callback?("manualStop")
+        }
+    }
+
+    func audioData(data: Data) {
+        callback?("audioData")
+    }
+}

--- a/VoysisTests/CallbackMock.swift
+++ b/VoysisTests/CallbackMock.swift
@@ -1,10 +1,16 @@
 import Foundation
 
+class TestContext: Context {
+}
+
+class TestEntities: Entities {
+}
+
 class CallbackMock: Callback {
 
     var callback: ((String) -> Void)?
 
-    func success(response: ApiResponse) {
+    func success(response: StreamResponse<TestContext, TestEntities>) {
         callback?("success")
     }
 

--- a/VoysisTests/VoysisTests.swift
+++ b/VoysisTests/VoysisTests.swift
@@ -17,6 +17,7 @@ class VoysisTests: XCTestCase {
     private var context: Context?
     private var tokenManager: TokenManager!
     private var resreshToken = "token"
+    private var callbackMock = CallbackMock()
 
     override func setUp() {
         super.setUp()
@@ -24,13 +25,13 @@ class VoysisTests: XCTestCase {
         audioRecordManager = AudioRecordManagerMock()
         tokenManager = TokenManager(refreshToken: resreshToken, dispatchQueue: DispatchQueue.main)
         let feedbackManager = FeedbackManager(DispatchQueue.main)
-        feedbackManager.dispatchQueue = DispatchQueue.main
+        let callbackDispatcher = CallbackDispatcher(DispatchQueue.main)
         voysis = ServiceImpl(client: client,
                 recorder: audioRecordManager,
+                callbackDispatcher: callbackDispatcher,
                 feedbackManager: feedbackManager,
                 tokenManager: tokenManager,
-                userId: "",
-                dispatchQueue: DispatchQueue.main)
+                userId: "")
 
         //closure cannot be null but is not required for most tests.
         client.dataCallback = { ( data: Data) in
@@ -51,12 +52,13 @@ class VoysisTests: XCTestCase {
         client.setupStreamEvent = "{\"type\":\"notification\",\"notificationType\":\"vad_stop\"}"
         audioRecordManager.onDataResponse = { (data: Data, isRecording: Bool) in
         }
-        let voysisEvent = { (event: Event) in
-            if (event.type == EventType.recordingFinished) {
+        let callback = { (call: String) in
+            if (call == "vadReceived") {
                 vadReceived.fulfill()
             }
         }
-        voysis.startAudioQuery(context: context, eventHandler: voysisEvent, errorHandler: { (_: VoysisError) in })
+        callbackMock.callback = callback
+        voysis.startAudioQuery(context: context, callback: callbackMock)
         waitForExpectations(timeout: 5, handler: nil)
     }
 
@@ -79,23 +81,23 @@ class VoysisTests: XCTestCase {
             XCTAssertTrue(data.count == 1)
             endData.fulfill()
         }
-        let voysisEvent = { (event: Event) in
-            //ignore
-        }
         client.stringEvent = token
-        voysis.startAudioQuery(context: context, eventHandler: voysisEvent, errorHandler: { (_: VoysisError) in })
+        voysis.startAudioQuery(context: context, callback: callbackMock)
         voysis.finish()
         waitForExpectations(timeout: 5, handler: nil)
 
     }
 
-    func testErrorResposne() {
+    func testErrorResponse() {
         let errorReceived = expectation(description: "error received")
         client.error = VoysisError.unknownError
-        let errorHandler = { (_: VoysisError) in
-            errorReceived.fulfill()
+        let callback = { (call: String) in
+            if call == "failure" {
+                errorReceived.fulfill()
+            }
         }
-        voysis.startAudioQuery(context: context, eventHandler: { (_: Event) in }, errorHandler: errorHandler)
+        callbackMock.callback = callback
+        voysis.startAudioQuery(context: context, callback: callbackMock)
         waitForExpectations(timeout: 5, handler: nil)
     }
 
@@ -106,12 +108,13 @@ class VoysisTests: XCTestCase {
         audioRecordManager.onDataResponse = { (data: Data, isRecording: Bool) in
         }
         let completed = expectation(description: "completed")
-        let voysisEvent = { (event: Event) in
-            if (event.type == EventType.recordingFinished) {
+        let callback = { (call: String) in
+            if (call == "recordingFinished") {
                 completed.fulfill()
             }
         }
-        voysis.startAudioQuery(context: context, eventHandler: voysisEvent, errorHandler: { (_: VoysisError) in })
+        callbackMock.callback = callback
+        voysis.startAudioQuery(context: context, callback: callbackMock)
         XCTAssertEqual(voysis.state, State.busy)
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -125,7 +128,7 @@ class VoysisTests: XCTestCase {
             }
         }
         client.stringEvent = token
-        voysis.startAudioQuery(context: context, eventHandler: { (_: Event) in }, errorHandler: { (_: VoysisError) in })
+        voysis.startAudioQuery(context: context, callback: callbackMock)
         waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/VoysisTests/VoysisTests.swift
+++ b/VoysisTests/VoysisTests.swift
@@ -2,19 +2,14 @@ import XCTest
 @testable import Voysis
 
 class VoysisTests: XCTestCase {
-    class TestContext: Context {
-    }
-
-    class TestEntities: Entities {
-    }
 
     let token = "{\"type\":\"response\",\"entity\":{\"token\":\"1\",\"expiresAt\":\"2018-04-17T14:14:06.701Z\"},\"requestId\":\"0\",\"responseCode\":200,\"responseMessage\":\"OK\"}"
     let feedback = "{\"type\":\"response\",\"entity\":{},\"requestId\":\"0\",\"responseCode\":200,\"responseMessage\":\"OK\"}"
 
-    private var voysis: ServiceImpl<TestContext, TestEntities>!
+    private var voysis: ServiceImpl!
     private var audioRecordManager: AudioRecordManagerMock!
     private var client: ClientMock!
-    private var context: Context?
+    private var context: TestContext?
     private var tokenManager: TokenManager!
     private var resreshToken = "token"
     private var callbackMock = CallbackMock()
@@ -25,10 +20,9 @@ class VoysisTests: XCTestCase {
         audioRecordManager = AudioRecordManagerMock()
         tokenManager = TokenManager(refreshToken: resreshToken, dispatchQueue: DispatchQueue.main)
         let feedbackManager = FeedbackManager(DispatchQueue.main)
-        let callbackDispatcher = CallbackDispatcher(DispatchQueue.main)
         voysis = ServiceImpl(client: client,
                 recorder: audioRecordManager,
-                callbackDispatcher: callbackDispatcher,
+                dispatchQueue: DispatchQueue.main,
                 feedbackManager: feedbackManager,
                 tokenManager: tokenManager,
                 userId: "")
@@ -58,7 +52,7 @@ class VoysisTests: XCTestCase {
             }
         }
         callbackMock.callback = callback
-        voysis.startAudioQuery(context: context, callback: callbackMock)
+        voysis!.startAudioQuery(context: context, callback: callbackMock)
         waitForExpectations(timeout: 5, handler: nil)
     }
 

--- a/VoysisTests/VoysisTests.swift
+++ b/VoysisTests/VoysisTests.swift
@@ -109,7 +109,7 @@ class VoysisTests: XCTestCase {
         }
         let completed = expectation(description: "completed")
         let callback = { (call: String) in
-            if (call == "recordingFinished") {
+            if (call == "vadReceived") {
                 completed.fulfill()
             }
         }

--- a/example/VoysisDemo/VoysisDemo/ViewController.swift
+++ b/example/VoysisDemo/VoysisDemo/ViewController.swift
@@ -5,7 +5,7 @@ import AVFoundation
 class ViewController: UIViewController, Callback {
 
     private let config = Config(url: URL(string: "ws://INSERT_URL/websocketapi")!, refreshToken: "INSERT_TOKEN")
-    private lazy var voysis = Voysis.ServiceProvider<CommerceContext, CommerceEntities>.make(config: config)
+    private lazy var voysis = Voysis.ServiceProvider.make(config: config)
     private var context: CommerceContext?
 
     @IBOutlet weak var response: UITextView!

--- a/example/VoysisDemo/VoysisDemo/ViewController.swift
+++ b/example/VoysisDemo/VoysisDemo/ViewController.swift
@@ -45,17 +45,15 @@ class ViewController: UIViewController, Callback {
         }
     }
 
-    func success(response: ApiResponse) {
+    func success(response: StreamResponse<CommerceContext, CommerceEntities>) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
-        if let response = response as? StreamResponse<CommerceContext, CommerceEntities> {
-            if let context = response.context {
-                self.context = context
-            }
-            if let data = try? encoder.encode(response),
-               let json = String(data: data, encoding: .utf8) {
-                self.response.text = json
-            }
+        if let context = response.context {
+            self.context = context
+        }
+        if let data = try? encoder.encode(response),
+           let json = String(data: data, encoding: .utf8) {
+            self.response.text = json
         }
     }
 


### PR DESCRIPTION
- replaced call(event: Event) with individual callbacks. success/failure are mandatory, the rest are optional.
- Added FinishedReason enum used by recordingFinished() method.
- Added audioData callback containing recorded data.
- removed generics from serviceImpl, converted startAudioQuery to generic method.
- removed global callback from serviceImpl
- refactored serviceImpl. Removed labels from method.