### PR TITLE
recordingFinished notification bug.

### DIFF
--- a/Voysis/recorder/AudioRecorder.swift
+++ b/Voysis/recorder/AudioRecorder.swift
@@ -5,8 +5,8 @@ public protocol AudioRecorder {
     /**
      Parameter onDataResponse: called when audio buffer fills.
      */
-    func start(onDataResponse: @escaping ((Data, Bool) -> Void))
+    func start(onDataResponse: @escaping ((Data, FinishedReason?) -> Void))
 
     ///stop recording audio
-    func stop()
+    func stop(reason : FinishedReason)
 }

--- a/Voysis/recorder/AudioRecorder.swift
+++ b/Voysis/recorder/AudioRecorder.swift
@@ -5,8 +5,8 @@ public protocol AudioRecorder {
     /**
      Parameter onDataResponse: called when audio buffer fills.
      */
-    func start(onDataResponse: @escaping ((Data, FinishedReason?) -> Void))
+    func start(onDataResponse: @escaping ((Data) -> Void))
 
     ///stop recording audio
-    func stop(reason : FinishedReason)
+    func stop()
 }

--- a/Voysis/recorder/AudioRecorderImpl.swift
+++ b/Voysis/recorder/AudioRecorderImpl.swift
@@ -4,9 +4,8 @@ import AVFoundation
 
 class AudioRecorderImpl: AudioRecorder {
 
-    internal var onDataResponse: ((Data, FinishedReason?) -> Void)?
+    internal var onDataResponse: ((Data) -> Void)?
     private var format = AudioStreamBasicDescription()
-    private var finishedReason: FinishedReason?
     private var queue: AudioQueueRef?
     private var player: AudioPlayer
     private var inProgress = false
@@ -21,7 +20,7 @@ class AudioRecorderImpl: AudioRecorder {
         setFormatDescription()
     }
 
-    public func start(onDataResponse: @escaping ((Data, FinishedReason?) -> Void)) {
+    public func start(onDataResponse: @escaping ((Data) -> Void)) {
         guard !inProgress else {
             return
         }
@@ -39,11 +38,10 @@ class AudioRecorderImpl: AudioRecorder {
         }
     }
 
-    public func stop(reason: FinishedReason) {
+    public func stop() {
         guard inProgress else {
             return
         }
-        self.finishedReason = reason
 
         guard let queue = queue else {
             return
@@ -89,8 +87,7 @@ class AudioRecorderImpl: AudioRecorder {
         let buffer = bufferRef.pointee
         autoreleasepool {
             let data = Data(bytes: buffer.mAudioData, count: Int(buffer.mAudioDataByteSize))
-            audioRecorder.onDataResponse?(data, audioRecorder.finishedReason)
-            audioRecorder.finishedReason = nil
+            audioRecorder.onDataResponse?(data)
         }
 
         // return early if recording is stopped

--- a/Voysis/voysis/ServiceImpl.swift
+++ b/Voysis/voysis/ServiceImpl.swift
@@ -50,7 +50,6 @@ internal class ServiceImpl: Service {
     }
 
     public func finish() {
-        state = .processing
         stop(.manualStop, Data([4]))
     }
 
@@ -148,6 +147,7 @@ internal class ServiceImpl: Service {
     }
 
     private func stop(_ reason: FinishedReason, _ data: Data? = nil) {
+        state = .processing
         finishedReason = reason
         recorder.stop()
         queueAudio(data)
@@ -171,7 +171,6 @@ internal class ServiceImpl: Service {
             let event = try Converter.decodeResponse(json: data, context: T.C.self, entity: T.E.self)
             switch event.type {
             case .vadReceived:
-                state = .processing
                 stop(.vadReceived)
             case .audioQueryCompleted:
                 state = .idle

--- a/Voysis/voysis/api/Service.swift
+++ b/Voysis/voysis/api/Service.swift
@@ -4,7 +4,8 @@ public typealias FeedbackHandler = (Int) -> Void
 
 public enum State {
     case idle
-    case busy
+    case recording
+    case processing
 }
 
 public protocol Service {

--- a/VoysisTests/AudioRecordManagerMock.swift
+++ b/VoysisTests/AudioRecordManagerMock.swift
@@ -6,18 +6,24 @@ import Foundation
 * When stop recording called, onDataResponse called with isRecording false
 */
 class AudioRecordManagerMock: AudioRecorder {
-    var onDataResponse: ((Data, FinishedReason?) -> Void)?
+    var onDataResponse: ((Data) -> Void)?
+    var stopWithData: Bool = false
 
     var data : Data?
 
-    public func start(onDataResponse: @escaping ((Data, FinishedReason?) -> Void)) {
+    public func start(onDataResponse: @escaping ((Data) -> Void)) {
         if (self.onDataResponse != nil) {
             self.onDataResponse = onDataResponse
         }
-        onDataResponse(data ?? Data(), .manualStop)
+        onDataResponse(data ?? Data([1,2]))
     }
 
-    public func stop(reason : FinishedReason) {
-        onDataResponse?(Data(), reason)
+    public func stop() {
+        if stopWithData {
+            onDataResponse?(Data([4]))
+        }else{
+            onDataResponse?(Data())
+        }
+
     }
 }

--- a/VoysisTests/AudioRecordManagerMock.swift
+++ b/VoysisTests/AudioRecordManagerMock.swift
@@ -6,18 +6,18 @@ import Foundation
 * When stop recording called, onDataResponse called with isRecording false
 */
 class AudioRecordManagerMock: AudioRecorder {
-    var onDataResponse: ((Data, Bool) -> Void)?
+    var onDataResponse: ((Data, FinishedReason?) -> Void)?
 
     var data : Data?
 
-    public func start(onDataResponse: @escaping ((Data, Bool) -> Void)) {
+    public func start(onDataResponse: @escaping ((Data, FinishedReason?) -> Void)) {
         if (self.onDataResponse != nil) {
             self.onDataResponse = onDataResponse
         }
-        onDataResponse(data ?? Data(), true)
+        onDataResponse(data ?? Data(), .manualStop)
     }
 
-    public func stop() {
-        onDataResponse?(Data(), false)
+    public func stop(reason : FinishedReason) {
+        onDataResponse?(Data(), reason)
     }
 }

--- a/VoysisTests/VoysisTests.swift
+++ b/VoysisTests/VoysisTests.swift
@@ -44,8 +44,10 @@ class VoysisTests: XCTestCase {
         let vadReceived = expectation(description: "vad received")
         client.stringEvent = token
         client.setupStreamEvent = "{\"type\":\"notification\",\"notificationType\":\"vad_stop\"}"
-        audioRecordManager.onDataResponse = { (data: Data, isRecording: FinishedReason?) in
+        audioRecordManager.onDataResponse = { (data: Data) in
+
         }
+        audioRecordManager.stopWithData = true
         let callback = { (call: String) in
             if (call == "vadReceived") {
                 vadReceived.fulfill()
@@ -70,10 +72,15 @@ class VoysisTests: XCTestCase {
     }
 
     func testCreateAndManualFinishRequest() {
-        let endData = expectation(description: "4 bytes sent at end")
+        let endData = expectation(description: "one bytes sent at end")
+        let startData = expectation(description: "two bytes sent at end")
+        audioRecordManager.stopWithData = false
         client.dataCallback = { ( data: Data) in
-            XCTAssertTrue(data.count == 1)
-            endData.fulfill()
+            if data.count == 2 {
+                startData.fulfill()
+            } else if data.count == 1 {
+                endData.fulfill()
+            }
         }
         client.stringEvent = token
         voysis.startAudioQuery(context: context, callback: callbackMock)
@@ -99,17 +106,19 @@ class VoysisTests: XCTestCase {
         XCTAssertEqual(voysis.state, State.idle)
         client.stringEvent = token
         client.setupStreamEvent = "{\"type\":\"notification\",\"notificationType\":\"vad_stop\"}"
-        audioRecordManager.onDataResponse = { (data: Data, isRecording: FinishedReason?) in
+        audioRecordManager.onDataResponse = { (data: Data) in
         }
+        audioRecordManager.stopWithData = true
         let completed = expectation(description: "completed")
         let callback = { (call: String) in
             if (call == "vadReceived") {
                 completed.fulfill()
+                XCTAssertEqual(self.voysis.state, State.processing)
             }
         }
         callbackMock.callback = callback
         voysis.startAudioQuery(context: context, callback: callbackMock)
-        XCTAssertEqual(voysis.state, State.busy)
+        XCTAssertEqual(voysis.state, State.recording)
         waitForExpectations(timeout: 5, handler: nil)
     }
 

--- a/VoysisTests/VoysisTests.swift
+++ b/VoysisTests/VoysisTests.swift
@@ -44,7 +44,7 @@ class VoysisTests: XCTestCase {
         let vadReceived = expectation(description: "vad received")
         client.stringEvent = token
         client.setupStreamEvent = "{\"type\":\"notification\",\"notificationType\":\"vad_stop\"}"
-        audioRecordManager.onDataResponse = { (data: Data, isRecording: Bool) in
+        audioRecordManager.onDataResponse = { (data: Data, isRecording: FinishedReason?) in
         }
         let callback = { (call: String) in
             if (call == "vadReceived") {
@@ -99,7 +99,7 @@ class VoysisTests: XCTestCase {
         XCTAssertEqual(voysis.state, State.idle)
         client.stringEvent = token
         client.setupStreamEvent = "{\"type\":\"notification\",\"notificationType\":\"vad_stop\"}"
-        audioRecordManager.onDataResponse = { (data: Data, isRecording: Bool) in
+        audioRecordManager.onDataResponse = { (data: Data, isRecording: FinishedReason?) in
         }
         let completed = expectation(description: "completed")
         let callback = { (call: String) in

--- a/example/VoysisDemo/VoysisDemo/ViewController.swift
+++ b/example/VoysisDemo/VoysisDemo/ViewController.swift
@@ -18,7 +18,9 @@ class ViewController: UIViewController, Callback {
         switch voysis.state {
         case .idle:
             voysis.startAudioQuery(context: self.context, callback: self)
-        case .busy:
+        case .recording:
+            voysis.finish()
+        case .processing:
             voysis.cancel()
         }
     }


### PR DESCRIPTION
There's a small bug in the iOS sdk at the moment that when vad is received, the user gets a recordingFinished(reason) notification three times. one that says vad stop, 2 that say manualStop. The reason for this is that the recorsingFinshed callbacks are disjointed. when the audio callback occures with isRecording = false, we send a recordingFinished to the user. Because we record to multiple buffers this happens twice, also when vadReceived comes back from the server we notify the user.
  
To fix this Ive updated audioRecord interface to take a FinishedReason enum in its stop method and replaced the boolean isRecording with FinishedReason and am only calling recordingFinished from within this callback. When finishedReason is returned to serviceImpl it will notify the client. 