### PR TITLE
Added all argument constructors to Request and Response objects

### DIFF
--- a/Voysis/models/request/SocketRequest.swift
+++ b/Voysis/models/request/SocketRequest.swift
@@ -27,6 +27,10 @@ public struct RequestEntity<C: Context>: Codable {
 
 public struct AudioQuery: Codable {
     public let mimeType: String? = "audio/pcm"
+
+    public init(){
+
+    }
 }
 
 public struct Headers: Codable {

--- a/Voysis/models/response/SocketResponse.swift
+++ b/Voysis/models/response/SocketResponse.swift
@@ -9,14 +9,27 @@ internal struct Response<T: ApiResponse>: Codable {
 
 public struct Audio: Codable {
     public let href: String?
+
+    public init(href: String) {
+        self.href = href
+    }
 }
 
 public struct Reply: Codable {
     public let text: String?
+
+    public init(text: String?) {
+        self.text = text
+    }
 }
 
 public struct Links: Codable {
     public let linksSelf, audio: Audio?
+
+    public init(linksSelf: Audio?, audio: Audio?) {
+        self.linksSelf = linksSelf
+        self.audio = audio
+    }
 
     enum CodingKeys: String, CodingKey {
         case linksSelf = "self"
@@ -47,6 +60,30 @@ public struct StreamResponse<C: Context, E: Entities>: ApiResponse, Codable {
     public let entities: E?
     public let context: C?
     public let _links: Links?
+
+    public init(id: String?,
+                locale: String?,
+                conversationId: String?,
+                queryType: String?,
+                audioQuery: AudioQuery?,
+                textQuery: Reply?,
+                intent: String?,
+                reply: Reply?,
+                entities: E?,
+                context: C?,
+                _links: Links?) {
+        self.id = id
+        self.locale = locale
+        self.conversationId = conversationId
+        self.queryType = queryType
+        self.audioQuery = audioQuery
+        self.textQuery = textQuery
+        self.intent = intent
+        self.reply = reply
+        self.entities = entities
+        self.context = context
+        self._links = _links
+    }
 }
 
 public struct Token: ApiResponse, Codable {


### PR DESCRIPTION
I'm adding tests to our demo application. As a part of testing I want to mock the Voysis.Service and return a predetermined StreamResponse objects to test different code paths. At the moment I am not able to create StreamResponse objects because it requires an all args constructor which isn't available because of the way the Codable overrides the structs init() method. Ive added all args constructors to the necessary request and response objects to get around this.